### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/base64/_schema.yml
+++ b/_extensions/base64/_schema.yml
@@ -1,0 +1,24 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+shortcodes:
+  base64:
+    description: "Encode a file as a base64 string."
+    arguments:
+      - name: file
+        type: string
+        required: true
+        description: "Path to the file to encode."
+        completion:
+          type: file
+  base64-data:
+    description: "Encode a file as a base64 data URI with MIME type detection."
+    arguments:
+      - name: file
+        type: string
+        required: true
+        description: "Path to the file to encode."
+        completion:
+          type: file
+      - name: mime-type
+        type: string
+        description: "MIME type override (auto-detected from file extension if omitted)."

--- a/_extensions/base64/_snippets.json
+++ b/_extensions/base64/_snippets.json
@@ -7,14 +7,14 @@
     "description": "Encode a file as a base64 string."
   },
   "Base64 Data URI": {
-    "prefix": "base64-data",
+    "prefix": "data",
     "body": [
       "{{< base64-data ${1:path/to/file} >}}"
     ],
     "description": "Encode a file as a base64 data URI with automatic MIME type detection."
   },
   "Base64 Data URI with MIME Type": {
-    "prefix": "base64-data-mime",
+    "prefix": "data-mime",
     "body": [
       "{{< base64-data ${1:path/to/file} ${2:image/png} >}}"
     ],

--- a/_extensions/base64/_snippets.json
+++ b/_extensions/base64/_snippets.json
@@ -1,0 +1,23 @@
+{
+  "Base64 Encode": {
+    "prefix": "base64",
+    "body": [
+      "{{< base64 ${1:path/to/file} >}}"
+    ],
+    "description": "Encode a file as a base64 string."
+  },
+  "Base64 Data URI": {
+    "prefix": "base64-data",
+    "body": [
+      "{{< base64-data ${1:path/to/file} >}}"
+    ],
+    "description": "Encode a file as a base64 data URI with automatic MIME type detection."
+  },
+  "Base64 Data URI with MIME Type": {
+    "prefix": "base64-data-mime",
+    "body": [
+      "{{< base64-data ${1:path/to/file} ${2:image/png} >}}"
+    ],
+    "description": "Encode a file as a base64 data URI with an explicit MIME type."
+  }
+}


### PR DESCRIPTION
## Summary

- Add `_schema.yml` declaring the `base64` and `base64-data` shortcodes with their arguments.
- Add `_snippets.json` with three snippets: base64 encode, base64 data URI, and base64 data URI with explicit MIME type.

## What is Quarto Wizard?

[Quarto Wizard](https://m.canouil.dev/quarto-wizard/dev/) is a VS Code extension that enhances the Quarto authoring experience with IDE tooling.
In its upcoming release, Quarto extensions will be able to contribute their own schema and snippets, which Quarto Wizard can use to provide autocompletion, validation, diagnostics, and snippet completion tailored to each extension.

Extensions opt in by shipping a `_schema.yml` file (declaring configurable options, shortcode parameters, element attributes, and CSS classes) and a `_snippets.json` file (VS Code-format snippets for common syntax patterns) alongside their `_extension.yml`.

- [Schema specification](https://m.canouil.dev/quarto-wizard/dev/reference/schema-specification.html)
- [Snippet specification](https://m.canouil.dev/quarto-wizard/dev/reference/snippet-specification.html)